### PR TITLE
Fix semantic-release configuration for version parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ where = ["nextflow-api"]
 asyncio_mode = "auto"
 
 [tool.semantic_release]
-version_toml = "pyproject.toml:project.version"
+version_toml = [["pyproject.toml", "project.version"]]
 branch = "main"
-commit_parser = "angular"
+commit_parser = "conventional"
 changelog_file = "CHANGELOG.md"
 build_command = ""
 upload_to_repository = false


### PR DESCRIPTION
## Summary
- update python-semantic-release version_toml setting to the expected tuple format
- switch to the conventional commit parser to silence deprecation warning

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d834c411e08333a0bed0b1bcc4ff73