### PR TITLE
Fix semantic-release configuration parsing error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ where = ["nextflow-api"]
 asyncio_mode = "auto"
 
 [tool.semantic_release]
-version_toml = [["pyproject.toml", "project.version"]]
+version_toml = "pyproject.toml:project.version"
 branch = "main"
 commit_parser = "conventional"
 changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- correct the `version_toml` configuration to match the expected semantic-release format

## Testing
- pytest *(fails: missing dependency `pydantic` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83633db5c8333859a4b5a6764f0e7