### PR TITLE
fix: respect configured cors origins

### DIFF
--- a/nextflow_k8s_service/app/main.py
+++ b/nextflow_k8s_service/app/main.py
@@ -63,6 +63,8 @@ def get_state_store(request: Request) -> StateStore:
 
 
 def create_app() -> FastAPI:
+    settings = get_settings()
+
     app = FastAPI(
         title="Nextflow Pipeline Controller",
         version="0.1.0",
@@ -78,7 +80,7 @@ def create_app() -> FastAPI:
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=settings.allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
## Summary
- load service settings when constructing the FastAPI app
- use the configured allowed origins list for CORS middleware

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d84340b2a88333bf7a3ee908125830