### PR TITLE
fix: allow uv sync during docker build

### DIFF
--- a/nextflow_k8s_service/Dockerfile
+++ b/nextflow_k8s_service/Dockerfile
@@ -14,9 +14,11 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
 
-RUN uv sync --no-dev --frozen
+RUN uv sync --no-dev --frozen --no-install-project
 
 COPY nextflow_k8s_service ./nextflow_k8s_service
+
+RUN uv sync --no-dev --frozen --install-project
 
 ENV PATH="/app/.venv/bin:$PATH"
 


### PR DESCRIPTION
## Summary
- prevent uv sync from failing during Docker builds by syncing dependencies without the project first
- copy the application sources before installing the project package to ensure uv can find it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a28d3f608333937d8cf8d21c2a48