### PR TITLE
fix: broadcast to clients concurrently

### DIFF
--- a/nextflow_k8s_service/app/utils/broadcaster.py
+++ b/nextflow_k8s_service/app/utils/broadcaster.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from typing import Any, Set
@@ -15,6 +16,7 @@ class Broadcaster:
     def __init__(self) -> None:
         self._clients: Set[WebSocket] = set()
         self._lock = asyncio.Lock()
+        self._pending: dict[WebSocket, asyncio.Task[None]] = {}
 
     async def register(self, websocket: WebSocket) -> None:
         async with self._lock:
@@ -24,7 +26,10 @@ class Broadcaster:
     async def unregister(self, websocket: WebSocket) -> None:
         async with self._lock:
             self._clients.discard(websocket)
+            pending = self._pending.pop(websocket, None)
             logger.debug("WebSocket %s unregistered", id(websocket))
+        if pending is not None:
+            pending.cancel()
 
     async def broadcast(self, message: dict[str, Any]) -> None:
         payload = json.dumps(message, default=str)
@@ -41,4 +46,34 @@ class Broadcaster:
                 await self.unregister(client)
 
         for client in clients:
-            asyncio.create_task(_send(client))
+            async with self._lock:
+                pending = self._pending.get(client)
+                if pending and not pending.done():
+                    logger.warning(
+                        "Dropping slow WebSocket %s due to pending send", id(client)
+                    )
+                    drop_client = True
+                else:
+                    drop_client = False
+
+            if drop_client:
+                await self.unregister(client)
+                continue
+
+            task = asyncio.create_task(_send(client))
+            task.add_done_callback(
+                lambda completed, ws=client: asyncio.create_task(
+                    self._cleanup_pending(ws, completed)
+                )
+            )
+            async with self._lock:
+                self._pending[client] = task
+
+    async def _cleanup_pending(
+        self, client: WebSocket, task: asyncio.Task[None]
+    ) -> None:
+        with contextlib.suppress(Exception):
+            await task
+        async with self._lock:
+            if self._pending.get(client) is task:
+                self._pending.pop(client, None)

--- a/tests/test_broadcaster.py
+++ b/tests/test_broadcaster.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.utils.broadcaster import Broadcaster
+
+
+@pytest.mark.asyncio
+async def test_broadcast_does_not_block_on_slow_client(mocker):
+    broadcaster = Broadcaster()
+
+    slow_started = asyncio.Event()
+    slow_release = asyncio.Event()
+    fast_called = asyncio.Event()
+
+    slow_ws = mocker.Mock()
+    fast_ws = mocker.Mock()
+
+    async def slow_send(payload: str) -> None:
+        slow_started.set()
+        await slow_release.wait()
+
+    async def fast_send(payload: str) -> None:
+        fast_called.set()
+
+    slow_ws.send_text = mocker.AsyncMock(side_effect=slow_send)
+    fast_ws.send_text = mocker.AsyncMock(side_effect=fast_send)
+
+    await broadcaster.register(slow_ws)
+    await broadcaster.register(fast_ws)
+
+    broadcast_task = asyncio.create_task(broadcaster.broadcast({"message": "hello"}))
+
+    await asyncio.wait_for(slow_started.wait(), timeout=0.1)
+    await asyncio.sleep(0)  # allow fast client task to run
+
+    assert fast_ws.send_text.await_count == 1
+    assert fast_called.is_set()
+    assert broadcast_task.done()
+    await broadcast_task
+
+    slow_release.set()
+    await asyncio.sleep(0)
+    assert slow_ws.send_text.await_count == 1


### PR DESCRIPTION
## Summary
- update the WebSocket broadcaster to fire off per-client send operations concurrently while preserving exception handling
- add a regression test to ensure broadcasting does not block on slow clients

## Testing
- uv run pytest tests/test_broadcaster.py

------
https://chatgpt.com/codex/tasks/task_e_68dae0ae33e88333b98b7665c8910cea