### PR TITLE
fix: align slowapi middleware configuration

### DIFF
--- a/nextflow_k8s_service/app/main.py
+++ b/nextflow_k8s_service/app/main.py
@@ -75,7 +75,6 @@ def create_app() -> FastAPI:
 
     app.add_middleware(
         SlowAPIMiddleware,
-        limiter=limiter,
     )
 
     app.add_middleware(


### PR DESCRIPTION
## Summary
- remove the explicit limiter argument from SlowAPIMiddleware so it reads from app.state

## Testing
- uv run uvicorn app.main:app --app-dir nextflow_k8s_service --port 8000
- curl -s http://127.0.0.1:8000/healthz

------
https://chatgpt.com/codex/tasks/task_e_68db07562f2c83339dfa479902f04f31