### PR TITLE
feat: add /health endpoint alias

### DIFF
--- a/nextflow_k8s_service/README.md
+++ b/nextflow_k8s_service/README.md
@@ -51,7 +51,7 @@ k8s-manifests/            Deployment, service, ConfigMap, RBAC specs
 | DELETE | `/api/v1/pipeline/cancel`    | Cancel the active run |
 | GET    | `/api/v1/pipeline/history`   | List historical runs (bounded) |
 | WS     | `/api/v1/pipeline/stream`    | Receive live logs/status broadcasts |
-| GET    | `/healthz`                   | Service health probe |
+| GET    | `/health`, `/healthz`        | Service health probe |
 
 ## Kubernetes Deployment
 1. Build and push the service image (context is repo root):

--- a/nextflow_k8s_service/app/main.py
+++ b/nextflow_k8s_service/app/main.py
@@ -88,8 +88,7 @@ def create_app() -> FastAPI:
     app.include_router(pipeline_router, prefix="/api/v1")
     app.include_router(websocket_router, prefix="/api/v1")
 
-    @app.get("/healthz", tags=["health"])
-    async def healthcheck(state_store: StateStore = Depends(get_state_store)) -> dict[str, str]:
+    async def _healthcheck(state_store: StateStore = Depends(get_state_store)) -> dict[str, str]:
         try:
             await state_store.ping()
             status = "ok"
@@ -97,6 +96,9 @@ def create_app() -> FastAPI:
             logger.exception("Healthcheck failed: %s", exc)
             status = "degraded"
         return {"status": status}
+
+    app.get("/healthz", tags=["health"])(_healthcheck)
+    app.get("/health", tags=["health"])(_healthcheck)
 
     return app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ upload_to_release = true
 
 [dependency-groups]
 dev = [
+    "httpx>=0.28.1",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
     "pytest-mock>=3.15.1",

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_health_endpoints_return_ok_status() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        healthz_response = client.get("/healthz")
+        health_response = client.get("/health")
+
+    assert healthz_response.status_code == 200
+    assert health_response.status_code == 200
+
+    payload = {"status": "ok"}
+    assert healthz_response.json() == payload
+    assert health_response.json() == payload

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -198,6 +198,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -210,6 +223,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0a/0d4df132bfca1507114198b766f1737d57580c9ad1cf93c1ff673e3387be/httptools-0.6.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:342dd6946aa6bda4b8f18c734576106b8a31f2fe31492881a9a160ec84ff4bd5", size = 448858, upload-time = "2024-10-16T19:44:43.959Z" },
     { url = "https://files.pythonhosted.org/packages/1e/6a/787004fdef2cabea27bad1073bf6a33f2437b4dbd3b6fb4a9d71172b1c7c/httptools-0.6.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b36913ba52008249223042dca46e69967985fb4051951f94357ea681e1f5dc0", size = 452042, upload-time = "2024-10-16T19:44:45.071Z" },
     { url = "https://files.pythonhosted.org/packages/4d/dc/7decab5c404d1d2cdc1bb330b1bf70e83d6af0396fd4fc76fc60c0d522bf/httptools-0.6.4-cp313-cp313-win_amd64.whl", hash = "sha256:28908df1b9bb8187393d5b5db91435ccc9c8e891657f9cbb42a2541b44c82fc8", size = 87682, upload-time = "2024-10-16T19:44:46.46Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -338,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.0.9"
+version = "1.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -353,6 +381,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -376,6 +405,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },


### PR DESCRIPTION
## Summary
- expose the health check logic on both `/health` and `/healthz`
- document the new `/health` probe while retaining the existing path
- cover both endpoints with a regression test and add the httpx test dependency

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0ad027d08333b6e4095ba40a23d0