### PR TITLE
fix: add succeeded/failed counter fallback for job status detection

### DIFF
--- a/nextflow_k8s_service/app/kubernetes/jobs.py
+++ b/nextflow_k8s_service/app/kubernetes/jobs.py
@@ -129,7 +129,7 @@ async def get_job_status(job_name: str, settings: Settings) -> RunStatus:
     if status is None:
         return RunStatus.UNKNOWN
 
-    # Check conditions (authoritative for terminal states)
+    # Check conditions first (most authoritative)
     if status.conditions:
         for condition in status.conditions:
             if condition.type == "Complete" and condition.status == "True":
@@ -137,7 +137,11 @@ async def get_job_status(job_name: str, settings: Settings) -> RunStatus:
             if condition.type == "Failed" and condition.status == "True":
                 return RunStatus.FAILED
 
-    # Check if job is still active
+    # Fallback to counters (may be set before conditions in some K8s versions)
+    if status.succeeded and status.succeeded > 0:
+        return RunStatus.SUCCEEDED
+    if status.failed and status.failed > 0:
+        return RunStatus.FAILED
     if status.active and status.active > 0:
         return RunStatus.RUNNING
 

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.2.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Fixes the RunStatus.UNKNOWN issue by adding fallback checks for Kubernetes job status counters when conditions are not yet set.

## Problem

In v1.4.1, completed jobs are still being reported as `UNKNOWN` status. The current implementation only checks `status.conditions`, but Kubernetes may set the `succeeded` and `failed` counters before updating conditions, creating a timing window where completed jobs appear as unknown.

## Solution

Added fallback logic to check status counters after conditions:

```python
# Check conditions first (most authoritative)
if status.conditions:
    for condition in status.conditions:
        if condition.type == "Complete" and condition.status == "True":
            return RunStatus.SUCCEEDED
        if condition.type == "Failed" and condition.status == "True":
            return RunStatus.FAILED

# Fallback to counters (may be set before conditions in some K8s versions)
if status.succeeded and status.succeeded > 0:
    return RunStatus.SUCCEEDED
if status.failed and status.failed > 0:
    return RunStatus.FAILED
```

**Detection order:**
1. **Conditions** - Most authoritative, checked first
2. **Counters** (`succeeded`/`failed`) - Fallback for timing edge cases  
3. **Active counter** - Indicates job is still running
4. **UNKNOWN** - Default if no status indicators are set

## Changes

**Modified:** `app/kubernetes/jobs.py:140-146`
- Added `status.succeeded` and `status.failed` counter checks
- Positioned after condition checks but before `active` check
- Ensures status detection works regardless of which field Kubernetes updates first

## Test Plan

- [x] All existing tests pass
- [x] Code linted and formatted
- [ ] Deploy to staging and verify:
  - [ ] Successful pipeline runs show `SUCCEEDED` status
  - [ ] Failed pipeline runs show `FAILED` status  
  - [ ] No `UNKNOWN` statuses for completed jobs

## Impact

**Before:** Jobs complete successfully (4/4 tasks) but service reports `UNKNOWN` → immediate deletion  
**After:** Jobs correctly report `SUCCEEDED` or `FAILED` based on actual completion status

🤖 Generated with [Claude Code](https://claude.com/claude-code)