### PR TITLE
fix: properly catch CancelledError in WebSocket keepalive cleanup

### DIFF
--- a/nextflow_k8s_service/app/api/websocket.py
+++ b/nextflow_k8s_service/app/api/websocket.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -72,6 +71,8 @@ async def pipeline_stream(websocket: WebSocket) -> None:
         pass
     finally:
         keepalive_task.cancel()
-        with contextlib.suppress(Exception):
+        try:
             await keepalive_task
+        except asyncio.CancelledError:
+            pass  # Expected when keepalive task is cancelled
         await broadcaster.unregister(websocket)


### PR DESCRIPTION
## Summary

Fixes spurious ERROR logs when WebSocket connections close normally by properly catching `asyncio.CancelledError` during keepalive task cleanup.

## Problem

When a WebSocket client disconnects, the service logs an error:

```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/app/nextflow_k8s_service/app/api/websocket.py", line 76, in pipeline_stream
    await keepalive_task
  File "/app/nextflow_k8s_service/app/api/websocket.py", line 35, in _keepalive
    await asyncio.sleep(30)
asyncio.exceptions.CancelledError
```

**Root Cause:** In Python 3.8+, `asyncio.CancelledError` inherits from `BaseException`, not `Exception`. The previous code used `contextlib.suppress(Exception)` which doesn't catch `CancelledError`, allowing it to bubble up as an error.

## Solution

Replace the generic exception suppression with explicit `CancelledError` handling:

```python
# Before (doesn't catch CancelledError)
finally:
    keepalive_task.cancel()
    with contextlib.suppress(Exception):
        await keepalive_task

# After (properly catches CancelledError)
finally:
    keepalive_task.cancel()
    try:
        await keepalive_task
    except asyncio.CancelledError:
        pass  # Expected when keepalive task is cancelled
```

## Changes

**Modified:** `app/api/websocket.py:75-78`
- Replaced `contextlib.suppress(Exception)` with explicit try/except
- Catch `asyncio.CancelledError` specifically
- Removed unused `contextlib` import
- Added explanatory comment

## Why This Matters

**Inheritance hierarchy in Python 3.8+:**
```
BaseException
├── asyncio.CancelledError  ← Not caught by except Exception!
├── Exception
│   ├── RuntimeError
│   ├── ValueError
│   └── ...
```

This is expected behavior - when the WebSocket closes, we **should** cancel the keepalive task. The cancellation is not an error, it's proper cleanup.

## Test Plan

- [x] All existing tests pass
- [x] Code linted and formatted
- [ ] Deploy to staging and verify:
  - [ ] No ERROR logs when WebSocket clients disconnect
  - [ ] WebSocket connections still work normally
  - [ ] Keepalive tasks are properly cleaned up

## Impact

**Before:** Every WebSocket disconnection generates an ERROR log  
**After:** Clean disconnections with no error logs, only expected CancelledError handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)