### PR TITLE
fix: improve WebSocket connection visibility in logs

### DIFF
--- a/nextflow_k8s_service/app/utils/broadcaster.py
+++ b/nextflow_k8s_service/app/utils/broadcaster.py
@@ -41,7 +41,7 @@ class Broadcaster:
                 raise ConnectionLimitExceeded("WebSocket connection limit reached")
             self._clients.add(websocket)
             pending_count = len(self._clients)
-            logger.debug("WebSocket %s registered", id(websocket))
+            logger.info("WebSocket registered, total connected: %d", pending_count)
         if self._state_store:
             await self._state_store.set_connected_clients(pending_count)
 
@@ -50,7 +50,7 @@ class Broadcaster:
             self._clients.discard(websocket)
             pending = self._pending.pop(websocket, None)
             pending_count = len(self._clients)
-            logger.debug("WebSocket %s unregistered", id(websocket))
+            logger.info("WebSocket unregistered, total connected: %d", pending_count)
         if pending is not None:
             pending.cancel()
         if self._state_store:
@@ -79,10 +79,10 @@ class Broadcaster:
                 await client.send_text(payload)
             except (RuntimeError, WebSocketDisconnect):
                 # Expected: connection closed or message sent after close
-                logger.debug("WebSocket %s disconnected, unregistering", id(client))
+                logger.info("WebSocket disconnected during send, unregistering")
                 await self.unregister(client)
             except Exception:  # pragma: no cover - unexpected errors
-                logger.exception("Unexpected error sending to WebSocket %s", id(client))
+                logger.exception("Unexpected error sending to WebSocket")
                 await self.unregister(client)
 
         for client in clients:

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.4.5"
+version = "1.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Change WebSocket register/unregister logs from DEBUG to INFO level
- Show total connected clients count in log messages  
- Remove unnecessary client ID from logs

## Problem
WebSocket connection lifecycle was only logged at DEBUG level, making it impossible to diagnose connection issues when the service runs with default INFO logging. When investigating why `connected_clients: 0` despite frontend showing "connected", there were no logs to verify the backend actually received the connection.

## Solution
Changed `logger.debug()` to `logger.info()` for:
- WebSocket registration (with total count)
- WebSocket unregistration (with total count)
- WebSocket disconnection during broadcast

## Impact
Logs will now clearly show:
```
INFO: WebSocket registered, total connected: 1
INFO: WebSocket unregistered, total connected: 0
```

This enables diagnosing:
- Connection timing issues
- Immediate disconnections
- Counter tracking problems

## Testing
- ✅ All tests pass
- ✅ Linting and formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)