### PR TITLE
fix: add default outdir for nf-core pipelines

### DIFF
--- a/nextflow_k8s_service/app/kubernetes/jobs.py
+++ b/nextflow_k8s_service/app/kubernetes/jobs.py
@@ -46,6 +46,10 @@ def _build_job_manifest(
     # Nextflow core options use single dash, pipeline parameters use double dash
     nextflow_core_options = {"profile", "revision", "resume", "with-docker", "with-singularity", "with-conda"}
 
+    # Set default outdir if not provided (required by most nf-core pipelines)
+    if "outdir" not in params.parameters:
+        params.parameters["outdir"] = "/workspace/results"
+
     args = ["run", params.pipeline]
     for key, value in params.parameters.items():
         if key == "revision":

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.4.9"
+version = "1.4.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Auto-set `--outdir=/workspace/results` if not provided
- Simplifies API calls for nf-core test pipelines
- Users can still override by providing their own outdir

## Problem
nf-core pipelines require `--outdir` parameter, causing test runs to fail:

```
ERROR: Missing required parameter: --outdir
```

**Before this fix:**
```json
{
  "parameters": {
    "pipeline": "nf-core/fetchngs",
    "parameters": {
      "profile": "test",
      "outdir": "/workspace/results"  // Must specify!
    }
  }
}
```

Since test runs use ephemeral storage (pods deleted after 15 minutes), the output location doesn't matter for testing purposes.

## Solution
Add default `outdir` if not provided:

```python
if "outdir" not in params.parameters:
    params.parameters["outdir"] = "/workspace/results"
```

**After this fix:**
```json
{
  "parameters": {
    "pipeline": "nf-core/fetchngs",
    "parameters": {
      "profile": "test"  // outdir auto-added!
    }
  }
}
```

## Benefits
- ✅ Easier to run test pipelines (fewer required parameters)
- ✅ Better UX for quick testing
- ✅ Users can still override for production runs
- ✅ Matches ephemeral storage model (output deleted anyway)

## Testing
- ✅ All tests pass
- ✅ Linting and formatting clean
- Default only applied when outdir not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)