### PR TITLE
fix: improve LogStreamer logging visibility

### DIFF
--- a/nextflow_k8s_service/app/services/log_streamer.py
+++ b/nextflow_k8s_service/app/services/log_streamer.py
@@ -90,6 +90,7 @@ class LogStreamer:
                     await self._sleep(stop_event)
                     continue
 
+                logger.info("Fetching logs from %d pod(s) for run %s", len(pods), run_id)
                 preview_lines: list[str] = []
                 for pod in pods:
                     metadata = getattr(pod, "metadata", None)
@@ -108,7 +109,7 @@ class LogStreamer:
                                 since_time=since_time,
                             )
                         except Exception as exc:  # pragma: no cover - defensive
-                            logger.debug(
+                            logger.warning(
                                 "Unable to fetch logs for %s/%s: %s",
                                 pod_name,
                                 container_name,
@@ -119,7 +120,9 @@ class LogStreamer:
                         if not logs:
                             continue
 
-                        for line in logs.splitlines():
+                        log_lines = logs.splitlines()
+                        logger.info("Fetched %d log lines from %s/%s", len(log_lines), pod_name, container_name)
+                        for line in log_lines:
                             timestamp, message = self._split_timestamp(line)
                             effective_timestamp = timestamp or datetime.now(timezone.utc)
                             self._log_cursors[cursor_key] = effective_timestamp

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.4.10"
+version = "1.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Upgrade log fetch errors from DEBUG to WARNING
- Add INFO logs for pod discovery and successful log fetches
- Makes LogStreamer activity visible for debugging

## Problem
LogStreamer was silently failing or succeeding with no indication of activity. When logs weren't appearing on the frontend, there was no way to tell if:
- LogStreamer was finding pods
- Log fetching was succeeding or failing  
- What errors were occurring

**Current behavior:**
```
INFO: Starting log stream for run abc123
INFO: Stopped log stream for run abc123
```
No visibility into what happened between start and stop.

## Solution
Add logging at INFO and WARNING levels:

```python
# Show when fetching from pods
logger.info("Fetching logs from %d pod(s) for run %s", len(pods), run_id)

# Show successful fetches
logger.info("Fetched %d log lines from %s/%s", len(log_lines), pod_name, container_name)

# Show errors (was DEBUG, now WARNING)
logger.warning("Unable to fetch logs for %s/%s: %s", pod_name, container_name, exc)
```

**New behavior:**
```
INFO: Starting log stream for run abc123
INFO: Fetching logs from 1 pod(s) for run abc123
INFO: Fetched 25 log lines from nextflow-run-abc123-xyz/nextflow
INFO: Stopped log stream for run abc123
```

## Benefits
- ✅ Immediate visibility into LogStreamer operations
- ✅ Can diagnose if pods aren't being found
- ✅ Can see if log fetching is failing silently  
- ✅ Shows actual log activity (line counts)
- ✅ Errors are no longer hidden at DEBUG level

## Testing
- ✅ All tests pass
- ✅ Linting and formatting clean

After deployment, logs will clearly show what the LogStreamer is doing, making it easy to identify issues with log streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)