### PR TITLE
feat: always append k8s profile for Kubernetes execution

### DIFF
--- a/nextflow_k8s_service/app/kubernetes/jobs.py
+++ b/nextflow_k8s_service/app/kubernetes/jobs.py
@@ -66,6 +66,18 @@ def _build_job_manifest(
     nextflow_core_options = {"profile", "revision", "resume", "with-docker", "with-singularity", "with-conda"}
     boolean_core_options = {"resume", "with-docker", "with-singularity", "with-conda"}
 
+    # Always add k8s profile since we're running on Kubernetes
+    # If user specified other profiles (e.g., test), append k8s to the list
+    if "profile" in params.parameters:
+        existing = params.parameters["profile"]
+        if isinstance(existing, str):
+            profiles = [p.strip() for p in existing.split(",")]
+            if "k8s" not in profiles:
+                profiles.append("k8s")
+            params.parameters["profile"] = ",".join(profiles)
+    else:
+        params.parameters["profile"] = "k8s"
+
     # Set default outdir only for nf-core pipelines (required by most of them)
     if _is_nf_core_pipeline(params.pipeline) and "outdir" not in params.parameters:
         params.parameters["outdir"] = "/workspace/results"

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.4.12"
+version = "1.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Automatically appends `k8s` profile to all pipeline runs since the service always runs on Kubernetes
- Preserves user-specified profiles (e.g., `test`) by appending `k8s` to the comma-separated list
- Ensures each pipeline process runs in its own container with appropriate dependencies

## Changes

- When no profile specified: sets `profile` to `k8s`
- When profile already specified: appends `k8s` if not already present (e.g., `test` becomes `test,k8s`)

## Why

The main `nextflow/nextflow:latest` container only orchestrates workflows. Individual pipeline processes need to run in their own containers with the required tools (Python, etc.). The `k8s` profile enables Kubernetes executor mode where each process gets its own pod.

This fixes the "python: No such file or directory" errors in nf-core/fetchngs runs.

## Test plan

- [x] All existing tests pass
- [x] Added logic handles both new and existing profile parameters
- [ ] Deploy and verify nf-core/fetchngs runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)