### PR TITLE
fix: correct Nextflow k8s pod configuration syntax

### DIFF
--- a/nextflow_k8s_service/app/kubernetes/jobs.py
+++ b/nextflow_k8s_service/app/kubernetes/jobs.py
@@ -205,16 +205,16 @@ k8s {{
     storageMountPath = '/workspace'
     namespace = '{settings.nextflow_namespace}'
     serviceAccount = '{settings.nextflow_service_account}'
-    pod {{
+    pod = [
         [resourceLimits: [
             cpu: '{settings.worker_cpu_limit}',
             memory: '{settings.worker_memory_limit}'
-        ]]
+        ]],
         [resourceRequests: [
             cpu: '{settings.worker_cpu_request}',
             memory: '{settings.worker_memory_request}'
         ]]
-    }}
+    ]
 }}
 """
 

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.6.2"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Fixed invalid Nextflow k8s configuration syntax that was causing jobs to fail
- Changed `k8s.pod` from closure syntax `pod {{ }}` to list syntax `pod = [ ]`

## Context
Discovered during deployment verification of v1.7.0. Pipeline runs were failing with:
```
ERROR ~ Unknown config attribute `k8s.pod` -- check config file: /etc/nextflow/nextflow.config
```

The Nextflow k8s executor expects pod directives to be specified as a list, not a closure.

## Testing
- ✅ All existing tests pass
- Ready for deployment and manual testing with actual pipeline runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)