### PR TITLE
fix: add pod resource limits for worker pods

### DIFF
--- a/nextflow_k8s_service/app/config.py
+++ b/nextflow_k8s_service/app/config.py
@@ -37,10 +37,10 @@ class Settings(BaseSettings):
     controller_memory_limit: str = Field(default="4Gi")
 
     # Resource limits for Nextflow worker pods (pipeline tasks)
-    worker_cpu_request: str = Field(default="1")
-    worker_cpu_limit: str = Field(default="4")
-    worker_memory_request: str = Field(default="2 GB")
-    worker_memory_limit: str = Field(default="8 GB")
+    worker_cpu_request: str = Field(default="100m")
+    worker_cpu_limit: str = Field(default="1")
+    worker_memory_request: str = Field(default="256Mi")
+    worker_memory_limit: str = Field(default="1Gi")
 
 
 @lru_cache()


### PR DESCRIPTION
## Summary
- Configures Nextflow worker pods with explicit resource requests and limits using the `k8s.pod` directive
- Sets conservative defaults to work with ResourceQuota policies:
  - CPU: 100m request, 1 CPU limit
  - Memory: 256Mi request, 1Gi limit
- Removes old `cpuLimits` approach that only controlled CPU limits

## Why
The current v1.8.0 deployment fails when running workflows because:
1. The `nextflow` namespace has a ResourceQuota that requires all pods to specify `limits.cpu` and `limits.memory`
2. The previous configuration only set CPU/memory at the process level without pod-level resource limits
3. Nextflow worker pods were being rejected with: `"must specify limits.cpu for: nf-*"`

## Implementation
Uses the Nextflow `k8s.pod` directive with explicit `resources` block:
```groovy
process {
    executor = 'k8s'
    
    pod = [[
        resources: [
            requests: [cpu: '100m', memory: '256Mi'],
            limits: [cpu: '1', memory: '1Gi']
        ]
    ]]
}
```

This ensures all worker pods created by Nextflow have the required resource specifications.

## Test Plan
- [x] All tests pass
- [ ] Deploy to cluster and verify workflows can run successfully
- [ ] Verify pods are created with correct resource limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)