### PR TITLE
fix: drop legacy run request compatibility

### DIFF
--- a/nextflow_k8s_service/app/kubernetes/jobs.py
+++ b/nextflow_k8s_service/app/kubernetes/jobs.py
@@ -67,8 +67,9 @@ def _build_job_manifest(
     boolean_core_options = {"resume", "with-docker", "with-singularity", "with-conda"}
 
     # Set default outdir only for nf-core pipelines (required by most of them)
-    if _is_nf_core_pipeline(params.pipeline) and "outdir" not in params.parameters:
-        params.parameters["outdir"] = "/workspace/results"
+    pipeline_parameters = dict(params.parameters)
+    if _is_nf_core_pipeline(params.pipeline) and "outdir" not in pipeline_parameters:
+        pipeline_parameters["outdir"] = "/workspace/results"
 
     args = [
         "run",
@@ -76,7 +77,7 @@ def _build_job_manifest(
         "-c",
         "/etc/nextflow/nextflow.config",
     ]
-    for key, value in params.parameters.items():
+    for key, value in pipeline_parameters.items():
         if key == "revision":
             # Special handling for revision shorthand
             args.extend(["-r", str(value)])

--- a/nextflow_k8s_service/app/models.py
+++ b/nextflow_k8s_service/app/models.py
@@ -25,8 +25,7 @@ class PipelineParameters(BaseModel):
     parameters: Dict[str, Any] = Field(default_factory=dict, description="Arbitrary Nextflow parameters")
 
 
-class RunRequest(BaseModel):
-    parameters: PipelineParameters
+class RunRequest(PipelineParameters):
     triggered_by: Optional[str] = Field(None, description="Identifier for the caller that triggered the run")
 
 

--- a/nextflow_k8s_service/app/services/pipeline_manager.py
+++ b/nextflow_k8s_service/app/services/pipeline_manager.py
@@ -88,7 +88,7 @@ class PipelineManager:
         )
 
         try:
-            job = await jobs.create_job(run_id=run_id, params=request.parameters, settings=self._settings)
+            job = await jobs.create_job(run_id=run_id, params=request, settings=self._settings)
         except Exception as exc:
             run_info = await self._state_store.finish_active_run(RunStatus.FAILED, message=str(exc))
             await self._broadcast_message(

--- a/openapi.json
+++ b/openapi.json
@@ -334,38 +334,6 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "PipelineParameters": {
-        "properties": {
-          "pipeline": {
-            "type": "string",
-            "title": "Pipeline",
-            "description": "Name of the Nextflow pipeline to run"
-          },
-          "workdir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Workdir",
-            "description": "Working directory for pipeline execution"
-          },
-          "parameters": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Parameters",
-            "description": "Arbitrary Nextflow parameters"
-          }
-        },
-        "type": "object",
-        "required": [
-          "pipeline"
-        ],
-        "title": "PipelineParameters"
-      },
       "RunHistoryEntry": {
         "properties": {
           "run_id": {
@@ -500,8 +468,28 @@
       },
       "RunRequest": {
         "properties": {
+          "pipeline": {
+            "type": "string",
+            "title": "Pipeline",
+            "description": "Name of the Nextflow pipeline to run"
+          },
+          "workdir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workdir",
+            "description": "Working directory for pipeline execution"
+          },
           "parameters": {
-            "$ref": "#/components/schemas/PipelineParameters"
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Parameters",
+            "description": "Arbitrary Nextflow parameters"
           },
           "triggered_by": {
             "anyOf": [
@@ -518,7 +506,7 @@
         },
         "type": "object",
         "required": [
-          "parameters"
+          "pipeline"
         ],
         "title": "RunRequest"
       },

--- a/test_run.json
+++ b/test_run.json
@@ -1,6 +1,6 @@
 {
+  "pipeline": "nextflow-io/hello",
   "parameters": {
-    "pipeline": "nextflow-io/hello",
     "greeting": "Hello from v1.8.0!"
   }
 }

--- a/tests/test_kubernetes_jobs.py
+++ b/tests/test_kubernetes_jobs.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 from app.config import Settings
 from app.kubernetes.jobs import _build_job_manifest
-from app.models import PipelineParameters
+from app.models import RunRequest
 
 
-def _build_params(pipeline: str, **parameters) -> PipelineParameters:
-    return PipelineParameters(pipeline=pipeline, parameters=parameters)
+def _build_request(pipeline: str, **parameters: str) -> RunRequest:
+    payload: dict[str, object] = {"pipeline": pipeline, "parameters": parameters}
+    return RunRequest.model_validate(payload)
 
 
 def test_nf_core_pipeline_gets_default_outdir() -> None:
-    params = _build_params("nf-core/fetchngs")
+    params = _build_request("nf-core/fetchngs")
     settings = Settings()
 
     job = _build_job_manifest(run_id="run-123", params=params, settings=settings)
@@ -25,7 +26,7 @@ def test_nf_core_pipeline_gets_default_outdir() -> None:
 
 
 def test_non_nf_core_pipeline_does_not_receive_default_outdir() -> None:
-    params = _build_params("my-org/custom-pipeline")
+    params = _build_request("my-org/custom-pipeline")
     settings = Settings()
 
     job = _build_job_manifest(run_id="run-123", params=params, settings=settings)
@@ -33,10 +34,11 @@ def test_non_nf_core_pipeline_does_not_receive_default_outdir() -> None:
     container = job.spec.template.spec.containers[0]
 
     assert "--outdir" not in container.args
+    assert "outdir" not in params.parameters
 
 
 def test_nf_core_pipeline_respects_user_outdir() -> None:
-    params = _build_params("https://github.com/nf-core/rnaseq", outdir="/custom/path")
+    params = _build_request("https://github.com/nf-core/rnaseq", outdir="/custom/path")
     settings = Settings()
 
     job = _build_job_manifest(run_id="run-123", params=params, settings=settings)


### PR DESCRIPTION
## Summary
- flatten the RunRequest schema by inheriting pipeline parameters so the API expects top-level pipeline metadata
- update the pipeline manager, Kubernetes job helpers, and associated tests to work with the flattened request shape
- refresh the sample payload and generated OpenAPI spec to advertise the simpler request shape

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc77431e948333bdf76a2551c07245