### PR TITLE
fix: prefix run IDs with 'r' for Nextflow compatibility

### DIFF
--- a/nextflow_k8s_service/app/services/pipeline_manager.py
+++ b/nextflow_k8s_service/app/services/pipeline_manager.py
@@ -176,7 +176,7 @@ class PipelineManager:
                 websocket_url=websocket_url,
             )
 
-        run_id = uuid.uuid4().hex[:12]
+        run_id = f"r{uuid.uuid4().hex[:11]}"
         job_name = f"nextflow-run-{run_id}"
 
         acquired = await self._state_store.acquire_active_run(

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -84,7 +84,7 @@ async def test_start_demo_run_creates_new_job(mocker) -> None:
     fake_uuid = mocker.Mock(hex="1234567890abcdef")
     mocker.patch("app.services.pipeline_manager.uuid.uuid4", return_value=fake_uuid)
 
-    fake_job = SimpleNamespace(metadata=SimpleNamespace(name="nextflow-run-1234567890ab"))
+    fake_job = SimpleNamespace(metadata=SimpleNamespace(name="nextflow-run-r1234567890a"))
     mock_create = mocker.AsyncMock(return_value=fake_job)
     mocker.patch("app.services.pipeline_manager.jobs.create_demo_job", mock_create)
 
@@ -97,15 +97,15 @@ async def test_start_demo_run_creates_new_job(mocker) -> None:
 
     assert result.attached is False
     assert result.status == RunStatus.RUNNING
-    assert result.job_name == "nextflow-run-1234567890ab"
-    assert result.run_id == "1234567890ab"
+    assert result.job_name == "nextflow-run-r1234567890a"
+    assert result.run_id == "r1234567890a"
     assert result.websocket_url == "/api/v1/pipeline/stream"
 
     mock_create.assert_awaited_once()
     state_store.acquire_active_run.assert_awaited_once()
     state_store.update_active_status.assert_awaited_once_with(RunStatus.RUNNING)
-    log_streamer.start.assert_awaited_once_with(run_id="1234567890ab", job_name="nextflow-run-1234567890ab")
-    mock_schedule.assert_awaited_once_with(run_id="1234567890ab", job_name="nextflow-run-1234567890ab")
+    log_streamer.start.assert_awaited_once_with(run_id="r1234567890a", job_name="nextflow-run-r1234567890a")
+    mock_schedule.assert_awaited_once_with(run_id="r1234567890a", job_name="nextflow-run-r1234567890a")
     assert broadcaster.broadcast.await_count >= 2
     first_message = broadcaster.broadcast.await_args_list[0].args[0]
     assert first_message["type"] == StreamMessageType.STATUS.value
@@ -122,11 +122,11 @@ async def test_start_demo_run_broadcasts_complete_on_job_creation_failure(mocker
     state_store.update_progress.return_value = (0.0, None, None)
 
     run_info = RunInfo(
-        run_id="feedbead1234",
+        run_id="rfeedbead123",
         status=RunStatus.FAILED,
         started_at=datetime.now(timezone.utc),
         finished_at=None,
-        job_name="nextflow-run-feedbead1234",
+        job_name="nextflow-run-rfeedbead123",
         message="boom",
     )
     state_store.finish_active_run.return_value = run_info
@@ -166,8 +166,8 @@ async def test_start_demo_run_broadcasts_complete_on_job_creation_failure(mocker
     complete_payload = broadcast_calls[2].args[0]
     assert complete_payload["type"] == StreamMessageType.COMPLETE.value
     assert complete_payload["data"]["status"] == RunStatus.FAILED.value
-    assert complete_payload["data"]["run"]["run_id"] == "feedbead1234"
-    assert complete_payload["run_id"] == "feedbead1234"
+    assert complete_payload["data"]["run"]["run_id"] == "rfeedbead123"
+    assert complete_payload["run_id"] == "rfeedbead123"
 
 
 @pytest.mark.asyncio
@@ -200,7 +200,7 @@ async def test_start_demo_run_cleans_up_on_monitor_failure(mocker) -> None:
     fake_uuid = mocker.Mock(hex="1234567890abcdef")
     mocker.patch("app.services.pipeline_manager.uuid.uuid4", return_value=fake_uuid)
 
-    fake_job = SimpleNamespace(metadata=SimpleNamespace(name="nextflow-run-1234567890ab"))
+    fake_job = SimpleNamespace(metadata=SimpleNamespace(name="nextflow-run-r1234567890a"))
     mock_create = mocker.AsyncMock(return_value=fake_job)
     mocker.patch("app.services.pipeline_manager.jobs.create_demo_job", mock_create)
 
@@ -218,10 +218,10 @@ async def test_start_demo_run_cleans_up_on_monitor_failure(mocker) -> None:
 
     assert str(excinfo.value) == "monitor boom"
 
-    log_streamer.start.assert_awaited_once_with(run_id="1234567890ab", job_name="nextflow-run-1234567890ab")
-    log_streamer.stop.assert_awaited_once_with("1234567890ab")
+    log_streamer.start.assert_awaited_once_with(run_id="r1234567890a", job_name="nextflow-run-r1234567890a")
+    log_streamer.stop.assert_awaited_once_with("r1234567890a")
 
-    mock_delete.assert_awaited_once_with("nextflow-run-1234567890ab", settings=settings, grace_period_seconds=0)
+    mock_delete.assert_awaited_once_with("nextflow-run-r1234567890a", settings=settings, grace_period_seconds=0)
 
     state_store.finish_active_run.assert_awaited_once_with(RunStatus.FAILED, message="monitor boom")
     state_store.set_monitor_task.assert_awaited()
@@ -230,7 +230,7 @@ async def test_start_demo_run_cleans_up_on_monitor_failure(mocker) -> None:
     broadcast_payload = broadcaster.broadcast.await_args_list[-1].args[0]
     assert broadcast_payload["type"] == StreamMessageType.COMPLETE.value
     assert broadcast_payload["data"]["status"] == RunStatus.FAILED.value
-    assert broadcast_payload["run_id"] == "1234567890ab"
+    assert broadcast_payload["run_id"] == "r1234567890a"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.9.3"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fixes critical bug where run IDs could start with digits, causing Nextflow validation errors.

## Problem
Nextflow requires run names to match the pattern ^[a-z](?:[a-z\d]|[-_](?=[a-z\d])){0,79}$ (must start with a letter). The previous implementation using uuid.uuid4().hex[:12] could generate IDs starting with digits, causing runs to fail.

## Solution
- Changed run ID generation from uuid.uuid4().hex[:12] to f"r{uuid.uuid4().hex[:11]}"
- Run IDs now always start with 'r' and are 12 characters total
- Example: r1234567890a instead of 1234567890ab

## Testing
- All 19 tests passing
- Updated test fixtures to reflect new run ID format
- Verified locally that IDs now match Nextflow's requirements