### PR TITLE
fix: correct batch_id variable interpolation in GENERATE process

### DIFF
--- a/nextflow_k8s_service/workflows/demo.nf
+++ b/nextflow_k8s_service/workflows/demo.nf
@@ -20,7 +20,7 @@ process GENERATE {
     echo "Generating batch ${batch_id}..."
     sleep 5
     for i in {1..100}; do
-        echo "\${batch_id},\$((RANDOM % 1000)),\$((RANDOM % 100))" >> batch_${batch_id}.csv
+        echo "${batch_id},\$((RANDOM % 1000)),\$((RANDOM % 100))" >> batch_${batch_id}.csv
     done
     """
 }


### PR DESCRIPTION
## Summary
Fixes the "unbound variable" error in the demo pipeline by correcting Nextflow variable interpolation.

## Problem
The GENERATE process was using `\${batch_id}` (escaped), which made bash treat it as a shell variable instead of allowing Nextflow to interpolate it. This caused the error:
```
.command.sh: line 5: batch_id: unbound variable
```

## Solution
Changed line 23 from:
```nextflow
echo "\${batch_id},\$((RANDOM % 1000)),\$((RANDOM % 100))" >> batch_${batch_id}.csv
```

To:
```nextflow
echo "${batch_id},\$((RANDOM % 1000)),\$((RANDOM % 100))" >> batch_${batch_id}.csv
```

Now Nextflow properly interpolates `${batch_id}` before the script runs, while `\$((RANDOM))` remains escaped for bash evaluation.

## Testing
- Reviewed Nextflow documentation on variable interpolation
- Verified the fix follows the pattern: unescaped `${}` for Nextflow variables, escaped `\$` for shell variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)