### PR TITLE
fix: differentiate between submitted and running task states

### DIFF
--- a/nextflow_k8s_service/app/parsers/nextflow_log_parser.py
+++ b/nextflow_k8s_service/app/parsers/nextflow_log_parser.py
@@ -79,7 +79,7 @@ def parse_task_progress(line: str) -> Optional[NextflowTask]:
             tag=match.group("tag"),
             completed=0,
             total=1,
-            status=TaskStatus.RUNNING,
+            status=TaskStatus.PENDING,  # Submitted tasks are pending, not yet running
         )
 
     # Try cached pattern

--- a/nextflow_k8s_service/app/services/progress_calculator.py
+++ b/nextflow_k8s_service/app/services/progress_calculator.py
@@ -346,11 +346,12 @@ class ProgressCalculator:
 
         # Check REPORT dependencies
         report = phase_map.get("REPORT")
-        if report and report.status != PhaseStatus.PENDING:
+        if report and report.status == PhaseStatus.RUNNING:
             generate = phase_map.get("GENERATE")
             analyze = phase_map.get("ANALYZE")
 
-            # REPORT should only start after GENERATE and ANALYZE complete
+            # REPORT should only be actively running after GENERATE and ANALYZE complete
+            # Only check when REPORT is actually RUNNING, not just PENDING (submitted but waiting)
             if generate and generate.status != PhaseStatus.COMPLETED:
                 warnings.append("REPORT started before GENERATE completed")
                 workflow_valid = False

--- a/tests/test_nextflow_log_parser.py
+++ b/tests/test_nextflow_log_parser.py
@@ -1,0 +1,112 @@
+"""Tests for Nextflow log parser."""
+
+import pytest
+
+from app.models import TaskStatus
+from app.parsers.nextflow_log_parser import (
+    parse_task_progress,
+    parse_executor_info,
+)
+
+
+class TestNextflowLogParser:
+    """Test Nextflow log parsing functionality."""
+
+    def test_parse_submitted_task(self):
+        """Test that submitted tasks are marked as PENDING, not RUNNING."""
+        line = "[db/820120] Submitted process > GENERATE (1)"
+        task = parse_task_progress(line)
+
+        assert task is not None
+        assert task.task_id == "db/820120"
+        assert task.name == "GENERATE"
+        assert task.tag == "1"
+        assert task.status == TaskStatus.PENDING  # Should be PENDING when submitted
+        assert task.completed == 0
+        assert task.total == 1
+
+    def test_parse_cached_task(self):
+        """Test that cached tasks are marked as COMPLETED."""
+        line = "[db/820120] Cached process > GENERATE (1)"
+        task = parse_task_progress(line)
+
+        assert task is not None
+        assert task.task_id == "db/820120"
+        assert task.name == "GENERATE"
+        assert task.tag == "1"
+        assert task.status == TaskStatus.COMPLETED
+        assert task.completed == 1
+        assert task.total == 1
+
+    def test_parse_running_task(self):
+        """Test parsing of actively running tasks."""
+        line = "[93/a11859] process > ANALYZE (5) | 3 of 5"
+        task = parse_task_progress(line)
+
+        assert task is not None
+        assert task.task_id == "93/a11859"
+        assert task.name == "ANALYZE"
+        assert task.tag == "5"
+        assert task.status == TaskStatus.RUNNING
+        assert task.completed == 3
+        assert task.total == 5
+
+    def test_parse_completed_task(self):
+        """Test parsing of completed tasks."""
+        line = "[db/820120] GENERATE (2) | 5 of 5 ✔"
+        task = parse_task_progress(line)
+
+        assert task is not None
+        assert task.task_id == "db/820120"
+        assert task.name == "GENERATE"
+        assert task.tag == "2"
+        assert task.status == TaskStatus.COMPLETED
+        assert task.completed == 5
+        assert task.total == 5
+
+    def test_parse_failed_task(self):
+        """Test parsing of failed tasks."""
+        line = "[db/820120] GENERATE (2) | 3 of 5 ❌"
+        task = parse_task_progress(line)
+
+        assert task is not None
+        assert task.task_id == "db/820120"
+        assert task.name == "GENERATE"
+        assert task.tag == "2"
+        assert task.status == TaskStatus.FAILED
+        assert task.completed == 3
+        assert task.total == 5
+
+    def test_parse_executor_info(self):
+        """Test parsing of executor information."""
+        line = "executor > k8s (11)"
+        result = parse_executor_info(line)
+
+        assert result is not None
+        assert result == ("k8s", 11)
+
+    def test_parse_non_task_line(self):
+        """Test that non-task lines return None."""
+        lines = [
+            "Random log message",
+            "Pipeline started",
+            "[2024-01-01] Some timestamp",
+        ]
+
+        for line in lines:
+            assert parse_task_progress(line) is None
+
+    def test_submitted_report_task(self):
+        """Test that submitted REPORT task is PENDING until it actually runs."""
+        # This is the key test - REPORT should be PENDING when submitted
+        # It should only become RUNNING when it actually starts executing
+        line = "[ab/123456] Submitted process > REPORT"
+        task = parse_task_progress(line)
+
+        assert task is not None
+        assert task.task_id == "ab/123456"
+        assert task.name == "REPORT"
+        assert task.tag is None  # REPORT typically has no tag
+        assert task.status == TaskStatus.PENDING
+        assert task.completed == 0
+        assert task.total == 1

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-k8s-service"
-version = "1.13.1"
+version = "1.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Fixed incorrect health warnings about REPORT process starting before dependencies completed
- Changed task parser to mark "Submitted" tasks as PENDING instead of RUNNING
- Updated health validation to only check dependencies when tasks are actually RUNNING

## Problem
The workflow health monitoring was incorrectly flagging the REPORT process as violating dependencies when Nextflow submitted the task (but it was waiting for inputs). The Nextflow workflow itself was correctly configured with proper dependencies via `.collect()`, but the monitoring interpreted "Submitted" as "Running".

## Solution
1. **Parser fix**: When a task is "Submitted", it's now marked as `TaskStatus.PENDING` instead of `TaskStatus.RUNNING`
2. **Health check fix**: Only validate dependencies when REPORT phase is actually `PhaseStatus.RUNNING`, not when it's just PENDING
3. **Added tests**: Comprehensive test coverage for the parser to ensure correct state tracking

## Test plan
- [x] All existing tests pass
- [x] Added new test file `test_nextflow_log_parser.py` with 8 test cases
- [x] Verified submitted tasks are marked as PENDING
- [x] Verified health warnings only trigger for actual dependency violations
- [ ] Deploy and verify warnings no longer appear in production UI

## Impact
This fix ensures the UI accurately represents the workflow execution state without false warnings, improving user trust in the monitoring system.

Generated with [Claude Code](https://claude.com/claude-code)